### PR TITLE
TransactionId: implement Comparable<TransactionId> for use in ConcurrentSkipListMap

### DIFF
--- a/src/main/java/org/jscep/transaction/TransactionId.java
+++ b/src/main/java/org/jscep/transaction/TransactionId.java
@@ -15,7 +15,7 @@ import org.apache.commons.lang.ArrayUtils;
 /**
  * This class represents a SCEP <code>transactionID</code> attribute.
  */
-public final class TransactionId implements Serializable {
+public final class TransactionId implements Serializable, Comparable<TransactionId> {
     private static final long serialVersionUID = -5248125945726721520L;
     private static final AtomicLong ID_SOURCE = new AtomicLong();
     private final byte[] id;
@@ -105,6 +105,18 @@ public final class TransactionId implements Serializable {
 
         return Arrays.equals(id, that.id);
 
+    }
+    
+    @Override
+    public int compareTo(TransactionId that) {
+        for (int i = 0, j = 0; i < this.id.length && j < that.id.length; i++, j++) {
+            int a = (this.id[i] & 0xff);
+            int b = (that.id[j] & 0xff);
+            if (a != b) {
+                return a - b;
+            }
+        }
+        return this.id.length - that.id.length;
     }
 
     /**


### PR DESCRIPTION
It is currently not possible to use this ID in a ConcurrentSkipListMap or any type of Concurrent Tree because it doesn't have Comparable. So I found a lexicographic comparison algorithm for byte[] and compare the ID bytes of the two objects, so it will work in these types of data structures one might need when implementing concurrent SCEP processing.
