### PR TITLE
fix for #24

### DIFF
--- a/src/main/java/org/jscep/message/PkcsPkiEnvelopeDecoder.java
+++ b/src/main/java/org/jscep/message/PkcsPkiEnvelopeDecoder.java
@@ -109,7 +109,7 @@ public final class PkcsPkiEnvelopeDecoder {
     }
     
     private static class InternalKeyTransEnvelopedRecipient extends JceKeyTransEnvelopedRecipient {
-        private static final String RSA = "RSA";
+        private static final String RSA = "RSA/ECB/PKCS1Padding";
         private static final String DES = "DES";
         private final PrivateKey wrappingKey;
         


### PR DESCRIPTION
fix for "org.bouncycastle.cms.CMSException: Could not create DES cipher" caused by "java.security.InvalidKeyException: DES key too long - should be 8 bytes" (issue #24)
