### PR TITLE
org.jscep.client.Client.getCertificate(): use subject name of the CA to ...

### DIFF
--- a/src/main/java/org/jscep/client/Client.java
+++ b/src/main/java/org/jscep/client/Client.java
@@ -529,7 +529,7 @@ public final class Client {
         CertStoreInspector certs = inspectorFactory.getInstance(store);
         final X509Certificate ca = certs.getIssuer();
 
-        X500Name name = new X500Name(ca.getIssuerX500Principal().toString());
+        X500Name name = new X500Name(ca.getSubjectX500Principal().toString());
         IssuerAndSerialNumber iasn = new IssuerAndSerialNumber(name, serial);
         Transport transport = createTransport(profile);
         final Transaction t = new NonEnrollmentTransaction(transport,


### PR DESCRIPTION
...build the iasn (instead of issuer name of the CA)

We want to build the iasn for the client certificate. But the _issuer_ of the client certificate is the
_subject_ of the CA.
