### PR TITLE
Currently, the fingerprint in the MessageDigestCertificateVerifier.ja…

### DIFF
--- a/src/main/java/org/jscep/client/Client.java
+++ b/src/main/java/org/jscep/client/Client.java
@@ -668,7 +668,7 @@ public final class Client {
         PkiMessageDecoder decoder = getDecoder(identity, identityKey, profile);
 
         IssuerAndSubject ias = new IssuerAndSubject(X500Utils.toX500Name(issuer
-                .getIssuerX500Principal()), X500Utils.toX500Name(subject));
+                .getSubjectX500Principal()), X500Utils.toX500Name(subject));
 
         final EnrollmentTransaction trans = new EnrollmentTransaction(
                 transport, encoder, decoder, ias, transId);

--- a/src/main/java/org/jscep/client/verification/MessageDigestCertificateVerifier.java
+++ b/src/main/java/org/jscep/client/verification/MessageDigestCertificateVerifier.java
@@ -55,6 +55,13 @@ public final class MessageDigestCertificateVerifier implements
         byte[] actual;
         try {
             digest.reset();
+            actual = digest.digest(cert.getEncoded());
+            if(Arrays.equals(actual, expected))
+            {
+                return true;
+            }
+
+            // the following code is for backwards compatibility
             actual = digest.digest(cert.getTBSCertificate());
         } catch (CertificateEncodingException e) {
             return false;

--- a/src/main/java/org/jscep/client/verification/MessageDigestCertificateVerifier.java
+++ b/src/main/java/org/jscep/client/verification/MessageDigestCertificateVerifier.java
@@ -6,6 +6,8 @@ import java.security.cert.X509Certificate;
 import java.util.Arrays;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This <tt>CertificateVerifier</tt> uses a pre-provisioned message digest to
@@ -23,6 +25,9 @@ import org.apache.commons.lang.ArrayUtils;
  */
 public final class MessageDigestCertificateVerifier implements
         CertificateVerifier {
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(MessageDigestCertificateVerifier.class);
+
     /**
      * The digest to use.
      */
@@ -52,10 +57,9 @@ public final class MessageDigestCertificateVerifier implements
      */
     @Override
     public boolean verify(final X509Certificate cert) {
-        byte[] actual;
         try {
             digest.reset();
-            actual = digest.digest(cert.getEncoded());
+            byte[] actual = digest.digest(cert.getEncoded());
             if(Arrays.equals(actual, expected))
             {
                 return true;
@@ -63,10 +67,17 @@ public final class MessageDigestCertificateVerifier implements
 
             // the following code is for backwards compatibility
             actual = digest.digest(cert.getTBSCertificate());
+            if(Arrays.equals(actual, expected))
+            {
+                LOGGER.warn("MessageDigest over the Certificate.tbsCertificate is configured, "
+                        + "but it should be over the DER encoded Certificate");
+                return true;
+            } else
+            {
+                return false;
+            }
         } catch (CertificateEncodingException e) {
             return false;
         }
-
-        return Arrays.equals(actual, expected);
     }
 }

--- a/src/test/java/org/jscep/client/verification/MessageDigestCertificateVerifierTest.java
+++ b/src/test/java/org/jscep/client/verification/MessageDigestCertificateVerifierTest.java
@@ -45,14 +45,21 @@ public class MessageDigestCertificateVerifierTest {
         CertificateVerifier verifier = new MessageDigestCertificateVerifier(
                 digest, expected);
         assertTrue(verifier.verify(cert));
-
-        // For backwards compatibility, make sure that the MessageDigestCertificateVerifier
-        // works with the fingerprint over TBSCertificate.
-        byte[] tbsExpected = digest.digest(cert.getTBSCertificate());
-
-        CertificateVerifier tbsVerifier = new MessageDigestCertificateVerifier(
-                digest, tbsExpected);
-        assertTrue(tbsVerifier.verify(cert));
     }
 
+    // For backwards compatibility, make sure that the MessageDigestCertificateVerifier
+    // works with the fingerprint over TBSCertificate.
+    @Theory
+    public void testVerifyTbsCertificate(MessageDigest digest) throws Exception {
+        X500Principal subject = new X500Principal("CN=example");
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        X509Certificate cert = X509Certificates.createEphemeral(subject,
+                keyPair);
+
+        byte[] expected = digest.digest(cert.getTBSCertificate());
+
+        CertificateVerifier verifier = new MessageDigestCertificateVerifier(
+                digest, expected);
+        assertTrue(verifier.verify(cert));
+    }
 }

--- a/src/test/java/org/jscep/client/verification/MessageDigestCertificateVerifierTest.java
+++ b/src/test/java/org/jscep/client/verification/MessageDigestCertificateVerifierTest.java
@@ -40,10 +40,19 @@ public class MessageDigestCertificateVerifierTest {
         X509Certificate cert = X509Certificates.createEphemeral(subject,
                 keyPair);
 
-        byte[] expected = digest.digest(cert.getTBSCertificate());
+        byte[] expected = digest.digest(cert.getEncoded());
 
         CertificateVerifier verifier = new MessageDigestCertificateVerifier(
                 digest, expected);
         assertTrue(verifier.verify(cert));
+
+        // For backwards compatibility, make sure that the MessageDigestCertificateVerifier
+        // works with the fingerprint over TBSCertificate.
+        byte[] tbsExpected = digest.digest(cert.getTBSCertificate());
+
+        CertificateVerifier tbsVerifier = new MessageDigestCertificateVerifier(
+                digest, tbsExpected);
+        assertTrue(tbsVerifier.verify(cert));
     }
+
 }


### PR DESCRIPTION
…va is computed over

the Certificate.tbsCertificate. However, the common method is over the whole binary
DER-encoded certificate (this can be verified by the command "openssl x509 -fingerprint").

I have extended MessageDigestCertificateVerifier to accept fingerprint computed both over the
whole certificate and, for backwords comptability, over only Certificate.tbsCertificate.