### PR TITLE
Hotfix/1.3.1-bouncycastle-146

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.google.code.jscep</groupId>
     <artifactId>jscep</artifactId>
     <packaging>jar</packaging>
-    <version>1.3.1</version>
+    <version>1.3.1-BC146</version>
     <name>jscep</name>
     <description>Java implementation of the Simple Certificate Enrollment Protocol</description>
     <url>http://jscep.org/</url>
@@ -195,12 +195,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk16</artifactId>
-            <version>1.45</version>
+            <version>1.46</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcmail-jdk16</artifactId>
-            <version>1.45</version>
+            <version>1.46</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -243,9 +243,9 @@
             <version>10.0.1</version>
         </dependency>
         <dependency>
-            <groupId>findbugs</groupId>
+            <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
-            <version>0.9.3</version>
+            <version>[2.0,3.0)</version>
         </dependency>
     </dependencies>
     <ciManagement>

--- a/src/main/java/org/jscep/server/ScepServlet.java
+++ b/src/main/java/org/jscep/server/ScepServlet.java
@@ -190,7 +190,7 @@ public abstract class ScepServlet extends HttpServlet {
 
             if (msgType == MessageType.GET_CERT) {
                 final IssuerAndSerialNumber iasn = (IssuerAndSerialNumber) msgData;
-                final X509Name principal = iasn.getName();
+                final X509Name principal = X509Name.getInstance(iasn.getName());
                 final BigInteger serial = iasn.getSerialNumber().getValue();
 
                 try {
@@ -233,7 +233,7 @@ public abstract class ScepServlet extends HttpServlet {
                 }
             } else if (msgType == MessageType.GET_CRL) {
                 final IssuerAndSerialNumber iasn = (IssuerAndSerialNumber) msgData;
-                final X509Name issuer = iasn.getName();
+                final X509Name issuer = X509Name.getInstance(iasn.getName());
                 final BigInteger serialNumber = iasn.getSerialNumber().getValue();
 
                 try {


### PR DESCRIPTION
Hi, 

This might be a somewhat silly request but is it possible to publish a `1.3.1-??` or `1.3.2` version specifically compiled with BouncyCastle `1.46`? Here's my backstory.

I work on a product that uses an older jscep version `1.3.x` and BC 1.46 in it's code base. The efforts to migrate to the latest version of BC (which has to happen eventually) are too big at the moment. I wanted to use jscep from the maven repo, but it's compiled against BC 1.45 and that introduces a `java.lang.NoClassDefFoundError: org.jscep.util.AlgorithmDictionary (initialization failure)` JVM exception the reason for which I haven't been able to identify exactly. It probably has to do with static initializers and some BC static variables.

As far as I saw none of the tagged versions were compiled against BC 1.46. I think there was a jump from 1.45 to 1.47, hence the PR. 