### PR TITLE
Added support for AES128 in envelope encryption algorithm

### DIFF
--- a/src/main/java/org/jscep/message/PkcsPkiEnvelopeEncoder.java
+++ b/src/main/java/org/jscep/message/PkcsPkiEnvelopeEncoder.java
@@ -2,6 +2,7 @@ package org.jscep.message;
 
 import static org.bouncycastle.cms.CMSAlgorithm.DES_CBC;
 import static org.bouncycastle.cms.CMSAlgorithm.DES_EDE3_CBC;
+import static org.bouncycastle.cms.CMSAlgorithm.AES128_CBC;
 
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
@@ -103,7 +104,11 @@ public final class PkcsPkiEnvelopeEncoder {
     private OutputEncryptor getEncryptor() throws CMSException {
         if ("DES".equals(encAlg)) {
             return new JceCMSContentEncryptorBuilder(DES_CBC).build();
-        } else {
+        } 
+        else if("AES_128".equals(encAlg)){
+        	return new JceCMSContentEncryptorBuilder(AES128_CBC).build();
+        }
+        else {
             return new JceCMSContentEncryptorBuilder(DES_EDE3_CBC).build();
         }
     }

--- a/src/test/java/org/jscep/message/PkiMessageEncoderTest.java
+++ b/src/test/java/org/jscep/message/PkiMessageEncoderTest.java
@@ -250,4 +250,29 @@ public class PkiMessageEncoderTest {
         ContentInfo ci2 = new ContentInfo(ci.getContentType(), content2);
         return new CMSSignedData(ci2);
     }
+    @Test
+    public void simpleTestAES128() throws Exception {
+        KeyPair caPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        X509Certificate ca = X509Certificates.createEphemeral(
+                new X500Principal("CN=CA"), caPair);
+
+        KeyPair clientPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        X509Certificate client = X509Certificates.createEphemeral(
+                new X500Principal("CN=Client"), clientPair);
+
+        // Everything below this line only available to client
+        PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(ca,
+                "AES_128");
+        PkiMessageEncoder encoder = new PkiMessageEncoder(
+                clientPair.getPrivate(), client, envEncoder);
+
+        PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(ca,
+                caPair.getPrivate());
+        PkiMessageDecoder decoder = new PkiMessageDecoder(client, envDecoder);
+
+        PkiMessage<?> actual = decoder.decode(encoder.encode(message));
+
+        assertEquals(message, actual);
+    }
 }


### PR DESCRIPTION
Why: Many SCEP servers might have capabilities to use AES-128 for symmetric encyption.
What: Added support and the relevant test(s).

Fixes #61