### PR TITLE
Add support for AES-192 and AES-256

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,8 +332,13 @@ Capabilities capabilities = client.getCaCapabilities();
  - SHA-512
 - Ciphers:
  - DES
- - Triple DES
+ - Triple DES ( default )
+ - AES-128
+ - AES-192
+ - AES-256 
 - Use of HTTP POST (See: http://tools.ietf.org/html/draft-nourse-scep-23#appendix-C)
+
+Note: AES-192 and AES-256 needs unrestricted policy JARs
 
 ## CA Key Rollover
 

--- a/src/main/java/org/jscep/message/PkcsPkiEnvelopeEncoder.java
+++ b/src/main/java/org/jscep/message/PkcsPkiEnvelopeEncoder.java
@@ -3,6 +3,8 @@ package org.jscep.message;
 import static org.bouncycastle.cms.CMSAlgorithm.DES_CBC;
 import static org.bouncycastle.cms.CMSAlgorithm.DES_EDE3_CBC;
 import static org.bouncycastle.cms.CMSAlgorithm.AES128_CBC;
+import static org.bouncycastle.cms.CMSAlgorithm.AES192_CBC;
+import static org.bouncycastle.cms.CMSAlgorithm.AES256_CBC;
 
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
@@ -107,6 +109,12 @@ public final class PkcsPkiEnvelopeEncoder {
         } 
         else if("AES_128".equals(encAlg)){
         	return new JceCMSContentEncryptorBuilder(AES128_CBC).build();
+        }
+        else if ("AES_192".equals(encAlg)) {
+            return new JceCMSContentEncryptorBuilder(AES192_CBC).build();
+        }
+        else if ("AES_256".equals(encAlg)) {
+            return new JceCMSContentEncryptorBuilder(AES256_CBC).build();
         }
         else {
             return new JceCMSContentEncryptorBuilder(DES_EDE3_CBC).build();

--- a/src/test/java/org/jscep/message/PkiMessageEncoderTest.java
+++ b/src/test/java/org/jscep/message/PkiMessageEncoderTest.java
@@ -7,6 +7,7 @@ import java.math.BigInteger;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
@@ -106,56 +107,35 @@ public class PkiMessageEncoderTest {
     }
 
     @Test
-    public void simpleTest() throws Exception {
-        KeyPair caPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
-        X509Certificate ca = X509Certificates.createEphemeral(
-                new X500Principal("CN=CA"), caPair);
-
-        KeyPair clientPair = KeyPairGenerator.getInstance("RSA")
-                .generateKeyPair();
-        X509Certificate client = X509Certificates.createEphemeral(
-                new X500Principal("CN=Client"), clientPair);
-
-        // Everything below this line only available to client
-        PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(ca,
-                "DES");
-        PkiMessageEncoder encoder = new PkiMessageEncoder(
-                clientPair.getPrivate(), client, envEncoder);
-
-        PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(ca,
-                caPair.getPrivate());
-        PkiMessageDecoder decoder = new PkiMessageDecoder(client, envDecoder);
-
-        PkiMessage<?> actual = decoder.decode(encoder.encode(message));
-
+    public void simpleTestDES() throws Exception {
+    	PkiMessage<?> actual = encodeAndDecodeEnvelope("DES");
         assertEquals(message, actual);
     }
     
     @Test
     public void simpleTestTripleDES() throws Exception {
-        KeyPair caPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
-        X509Certificate ca = X509Certificates.createEphemeral(
-                new X500Principal("CN=CA"), caPair);
-
-        KeyPair clientPair = KeyPairGenerator.getInstance("RSA")
-                .generateKeyPair();
-        X509Certificate client = X509Certificates.createEphemeral(
-                new X500Principal("CN=Client"), clientPair);
-
-        // Everything below this line only available to client
-        PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(ca,
-                "DESede");
-        PkiMessageEncoder encoder = new PkiMessageEncoder(
-                clientPair.getPrivate(), client, envEncoder);
-
-        PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(ca,
-                caPair.getPrivate());
-        PkiMessageDecoder decoder = new PkiMessageDecoder(client, envDecoder);
-
-        PkiMessage<?> actual = decoder.decode(encoder.encode(message));
-
+    	PkiMessage<?> actual = encodeAndDecodeEnvelope("DESede");
         assertEquals(message, actual);
     }
+    
+    @Test
+    public void simpleTestAES192() throws Exception {
+    	PkiMessage<?> actual = encodeAndDecodeEnvelope("AES_192");
+        assertEquals(message, actual);
+    }
+    
+    @Test
+    public void simpleTestAES256() throws Exception {
+    	PkiMessage<?> actual = encodeAndDecodeEnvelope("AES_256");
+        assertEquals(message, actual);
+    }
+    
+    @Test
+    public void simpleTestAES128() throws Exception {
+    	PkiMessage<?> actual = encodeAndDecodeEnvelope("AES_128");
+        assertEquals(message, actual);
+    }
+
 
     @Test
     public void invalidSignatureTest() throws Exception {
@@ -250,9 +230,9 @@ public class PkiMessageEncoderTest {
         ContentInfo ci2 = new ContentInfo(ci.getContentType(), content2);
         return new CMSSignedData(ci2);
     }
-    @Test
-    public void simpleTestAES128() throws Exception {
-        KeyPair caPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+    
+    public PkiMessage<?> encodeAndDecodeEnvelope(String cipherAlgorithm) throws Exception{
+    	KeyPair caPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
         X509Certificate ca = X509Certificates.createEphemeral(
                 new X500Principal("CN=CA"), caPair);
 
@@ -263,7 +243,7 @@ public class PkiMessageEncoderTest {
 
         // Everything below this line only available to client
         PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(ca,
-                "AES_128");
+                cipherAlgorithm);
         PkiMessageEncoder encoder = new PkiMessageEncoder(
                 clientPair.getPrivate(), client, envEncoder);
 
@@ -273,6 +253,7 @@ public class PkiMessageEncoderTest {
 
         PkiMessage<?> actual = decoder.decode(encoder.encode(message));
 
-        assertEquals(message, actual);
+        return actual;
+    	
     }
 }


### PR DESCRIPTION
Why:
The latest IETF draft https://tools.ietf.org/html/draft-gutmann-scep-03
has added support for AES symmetric cipher algorithm.

What:
Added AES-192 and AES-256 for optional usage, during which unrestricted policy JARS
need to be placed inside JVM lib/secuirty
Triple DES remains as the default symmetric cipher..

FIxes #64