### PR TITLE
Fix challenge password cast in CertificationRequestUtils

### DIFF
--- a/src/main/java/org/jscep/util/CertificationRequestUtils.java
+++ b/src/main/java/org/jscep/util/CertificationRequestUtils.java
@@ -12,7 +12,7 @@ import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.crypto.params.RSAKeyParameters;
 import org.bouncycastle.crypto.util.PublicKeyFactory;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
-import org.bouncycastle.asn1.DERPrintableString;
+import org.bouncycastle.asn1.ASN1String;
 import org.bouncycastle.asn1.pkcs.Attribute;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 
@@ -69,9 +69,12 @@ public final class CertificationRequestUtils {
         for (Attribute attr : attrs) {
             if (attr.getAttrType().equals(
                     PKCSObjectIdentifiers.pkcs_9_at_challengePassword)) {
-                DERPrintableString challangePassword = (DERPrintableString) attr
+                // According to RFC 2985 this may be any of the DirectoryString
+                // types, but we can be more flexible and allow any ASN.1
+                // string.
+                ASN1String challengePassword = (ASN1String) attr
                         .getAttrValues().getObjectAt(0);
-                return challangePassword.getString();
+                return challengePassword.getString();
             }
         }
         return null;

--- a/src/test/java/org/jscep/util/CertificationRequestUtilsTest.java
+++ b/src/test/java/org/jscep/util/CertificationRequestUtilsTest.java
@@ -1,0 +1,69 @@
+package org.jscep.util;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.DERPrintableString;
+import org.bouncycastle.asn1.DERUTF8String;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
+import org.junit.Test;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+
+public class CertificationRequestUtilsTest {
+    private PKCS10CertificationRequest getCsr(ASN1Encodable challengePassword)
+            throws Exception {
+
+        final X500Name subject = new X500Name("CN=Test");
+
+        final KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+            .genKeyPair();
+
+        final SubjectPublicKeyInfo pkInfo = SubjectPublicKeyInfo
+            .getInstance(keyPair.getPublic().getEncoded());
+
+        final ContentSigner signer = new JcaContentSignerBuilder(
+            "SHA1withRSA").build(keyPair.getPrivate());
+
+        final PKCS10CertificationRequestBuilder builder =
+            new PKCS10CertificationRequestBuilder(subject, pkInfo);
+        if (challengePassword != null) {
+            builder.addAttribute(
+                PKCSObjectIdentifiers.pkcs_9_at_challengePassword,
+                challengePassword);
+        }
+        return builder.build(signer);
+    }
+
+    @Test
+    public void testGetChallengePasswordPrintableString() throws Exception {
+        final PKCS10CertificationRequest csr = getCsr(new DERPrintableString(
+            "test password"));
+        assertThat(CertificationRequestUtils.getChallengePassword(csr),
+                   is("test password"));
+    }
+
+    @Test
+    public void testGetChallengePasswordUtf8String() throws Exception {
+        final PKCS10CertificationRequest csr = getCsr(new DERUTF8String(
+            "test_password"));
+        assertThat(CertificationRequestUtils.getChallengePassword(csr),
+                   is("test_password"));
+    }
+
+    @Test
+    public void testGetChallengePasswordNull() throws Exception {
+        final PKCS10CertificationRequest csr = getCsr(null);
+        assertThat(CertificationRequestUtils.getChallengePassword(csr),
+                   is(nullValue()));
+    }
+}


### PR DESCRIPTION
`CertificationRequestUtils.getChallengePassword` throws a `ClassCastException` if the challenge password is not an ASN.1 PrintableString.  However, per [RFC 2985](https://tools.ietf.org/html/rfc2985) (§ 5.4.1), the challenge password may be a different string type, such as UTF8String.

This PR fixes the issue by allowing any ASN.1 string type.  I also added some test cases for the relevant static method.