### PR TITLE
X509Certificate sender passed to doEnrol

### DIFF
--- a/src/main/java/org/jscep/server/ScepServlet.java
+++ b/src/main/java/org/jscep/server/ScepServlet.java
@@ -304,7 +304,7 @@ public abstract class ScepServlet extends HttpServlet {
 
                 try {
                     LOGGER.debug("Invoking doEnrol");
-                    List<X509Certificate> issued = doEnrol(certReq, transId);
+                    List<X509Certificate> issued = doEnrol(certReq, reqCert, transId);
 
                     if (issued.size() == 0) {
                         certRep = new CertRep(transId, senderNonce,
@@ -579,6 +579,7 @@ public abstract class ScepServlet extends HttpServlet {
      */
     protected abstract List<X509Certificate> doEnrol(
             final PKCS10CertificationRequest certificationRequest,
+            final X509Certificate sender,
             final TransactionId transId) throws Exception;
 
     /**

--- a/src/test/java/org/jscep/server/ScepServletTest.java
+++ b/src/test/java/org/jscep/server/ScepServletTest.java
@@ -41,12 +41,16 @@ import org.jscep.message.PkcsPkiEnvelopeEncoder;
 import org.jscep.message.PkiMessageDecoder;
 import org.jscep.message.PkiMessageEncoder;
 import org.jscep.transaction.EnrollmentTransaction;
+import org.jscep.transaction.FailInfo;
 import org.jscep.transaction.MessageType;
 import org.jscep.transaction.NonEnrollmentTransaction;
 import org.jscep.transaction.Transaction;
 import org.jscep.transaction.Transaction.State;
-import org.jscep.transport.*;
+import org.jscep.transport.Transport;
+import org.jscep.transport.TransportException;
+import org.jscep.transport.TransportFactory;
 import org.jscep.transport.TransportFactory.Method;
+import org.jscep.transport.UrlConnectionTransportFactory;
 import org.jscep.transport.request.GetCaCapsRequest;
 import org.jscep.transport.request.GetCaCertRequest;
 import org.jscep.transport.request.GetNextCaCertRequest;
@@ -291,6 +295,69 @@ public class ScepServletTest {
         assertThat(state, is(State.CERT_REQ_PENDING));
     }
 
+    @Test
+    public void testEnrollmentNotAuthorized() throws Exception {
+        PKCS10CertificationRequest csr = getCsr(name, pubKey, priKey,
+                null);
+
+        PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(
+                getRecipient(), "DES");
+        PkiMessageEncoder encoder = new PkiMessageEncoder(priKey, sender,
+                envEncoder);
+
+        PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(sender,
+                priKey);
+        PkiMessageDecoder decoder = new PkiMessageDecoder(getRecipient(),
+                envDecoder);
+
+        Transport transport = transportFactory.forMethod(Method.POST, getURL());
+        Transaction t = new EnrollmentTransaction(transport, encoder, decoder,
+                csr);
+
+        State s = t.send();
+        assertThat(s, is(State.CERT_NON_EXISTANT));
+        assertThat(t.getFailInfo(), is(FailInfo.badRequest));
+    }
+
+    @Test
+    public void testRenewal() throws Exception {
+        PKCS10CertificationRequest csr = getCsr(name, pubKey, priKey,
+                "password".toCharArray());
+
+        PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(
+                getRecipient(), "DES");
+        PkiMessageEncoder encoder = new PkiMessageEncoder(priKey, sender,
+                envEncoder);
+
+        PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(sender,
+                priKey);
+        PkiMessageDecoder decoder = new PkiMessageDecoder(getRecipient(),
+                envDecoder);
+
+        Transport transport = transportFactory.forMethod(Method.POST, getURL());
+        Transaction t = new EnrollmentTransaction(transport, encoder, decoder,
+                csr);
+
+        State s = t.send();
+        assertThat(s, is(State.CERT_ISSUED));
+        Certificate[] certificateChain = t.getCertStore()
+                .getCertificates(null)
+                .toArray(new Certificate[0]);
+        X509Certificate prevCertificate =
+                (X509Certificate) certificateChain[certificateChain.length - 1];
+
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA").genKeyPair();
+        PrivateKey newPriKey = keyPair.getPrivate();
+        PublicKey newPubKey = keyPair.getPublic();
+        csr = getCsr(name, newPubKey, newPriKey, null);
+        encoder = new PkiMessageEncoder(priKey, prevCertificate, envEncoder);
+        envDecoder = new PkcsPkiEnvelopeDecoder(prevCertificate, priKey);
+        decoder = new PkiMessageDecoder(getRecipient(), envDecoder);
+        t = new EnrollmentTransaction(transport, encoder, decoder, csr);
+        State renewalSate = t.send();
+        assertThat(renewalSate, is(State.CERT_ISSUED));
+    }
+
     private PKCS10CertificationRequest getCsr(X500Name subject,
             PublicKey pubKey, PrivateKey priKey, char[] password)
             throws GeneralSecurityException, IOException {
@@ -309,10 +376,14 @@ public class ScepServletTest {
             throw ioe;
         }
 
-        PKCS10CertificationRequestBuilder builder = new PKCS10CertificationRequestBuilder(
-                subject, pkInfo);
-        builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_challengePassword,
-                new DERPrintableString(new String(password)));
+        PKCS10CertificationRequestBuilder builder =
+                new PKCS10CertificationRequestBuilder(subject, pkInfo);
+        if (password != null) {
+            builder.addAttribute(
+                    PKCSObjectIdentifiers.pkcs_9_at_challengePassword,
+                    new DERPrintableString(new String(password))
+            );
+        }
 
         return builder.build(signer);
     }


### PR DESCRIPTION
Added X509Certificate sender parameter so that it's now possible to authorize renewal or update basing on the previously issued certificate.
Added negative test case for unauthorised enrollment (no password present) and test case for renewal with newly generated key-pair.