### PR TITLE
Enable BasicAuth if UserInfo is given in the SCEP-Server URL.

### DIFF
--- a/src/main/java/org/jscep/transport/AbstractTransport.java
+++ b/src/main/java/org/jscep/transport/AbstractTransport.java
@@ -26,6 +26,10 @@ public abstract class AbstractTransport implements Transport {
     public AbstractTransport(final URL url) {
         this.url = url;
         this.userInfo = url.getUserInfo();
+        
+        if (null != this.url && "http".equalsIgnoreCase(this.url.getProtocol())) {
+          System.err.println("WARNING: HTTP BasicAuth is used without SSL/TLS! Are you using a secure transport layer?");
+        }
     }
     
     /**

--- a/src/main/java/org/jscep/transport/AbstractTransport.java
+++ b/src/main/java/org/jscep/transport/AbstractTransport.java
@@ -15,6 +15,7 @@ import javax.net.ssl.SSLSocketFactory;
  */
 public abstract class AbstractTransport implements Transport {
     private final URL url;
+    private final String userInfo;
 
     /**
      * Creates a new <tt>AbstractTransport</tt> for the given URL.
@@ -24,6 +25,16 @@ public abstract class AbstractTransport implements Transport {
      */
     public AbstractTransport(final URL url) {
         this.url = url;
+        this.userInfo = url.getUserInfo();
+    }
+    
+    /**
+     * Returns the <tt>UserInfo</tt> for the transport.
+     *
+     * @return the <tt>UserInfo</tt> for the transport.
+     */
+    public final String getUserInfo() {
+      return this.userInfo;
     }
 
     /**

--- a/src/main/java/org/jscep/transport/UrlConnectionGetTransport.java
+++ b/src/main/java/org/jscep/transport/UrlConnectionGetTransport.java
@@ -9,6 +9,7 @@ import java.net.URLEncoder;
 
 import net.jcip.annotations.ThreadSafe;
 
+import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.jscep.transport.request.Operation;
 import org.jscep.transport.request.Request;

--- a/src/main/java/org/jscep/transport/UrlConnectionGetTransport.java
+++ b/src/main/java/org/jscep/transport/UrlConnectionGetTransport.java
@@ -72,7 +72,7 @@ final class UrlConnectionGetTransport extends AbstractTransport {
             if(conn instanceof HttpsURLConnection && sslSocketFactory != null){
                 ((HttpsURLConnection) conn).setSSLSocketFactory(sslSocketFactory);
             }
-            if (userInfo != null) {
+            if (userInfo != null && !userInfo.isEmpty()) {
               String encoded = new String(Base64.encode(userInfo.getBytes(Charsets.US_ASCII.name())), Charsets.US_ASCII.name());
               conn.setRequestProperty("Authorization", "Basic " + encoded);
           }

--- a/src/main/java/org/jscep/transport/UrlConnectionGetTransport.java
+++ b/src/main/java/org/jscep/transport/UrlConnectionGetTransport.java
@@ -19,6 +19,8 @@ import org.slf4j.LoggerFactory;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 
+import org.bouncycastle.util.encoders.Base64;
+
 /**
  * AbstractTransport representing the <code>HTTP GET</code> method
  */
@@ -60,6 +62,7 @@ final class UrlConnectionGetTransport extends AbstractTransport {
     public <T> T sendRequest(final Request msg,
             final ScepResponseHandler<T> handler) throws TransportException {
         URL url = getUrl(msg.getOperation(), msg.getMessage());
+        String userInfo = getUserInfo();
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Sending {} to {}", msg, url);
         }
@@ -69,6 +72,10 @@ final class UrlConnectionGetTransport extends AbstractTransport {
             if(conn instanceof HttpsURLConnection && sslSocketFactory != null){
                 ((HttpsURLConnection) conn).setSSLSocketFactory(sslSocketFactory);
             }
+            if (userInfo != null) {
+              String encoded = new String(Base64.encode(userInfo.getBytes(Charsets.US_ASCII.name())), Charsets.US_ASCII.name());
+              conn.setRequestProperty("Authorization", "Basic " + encoded);
+          }
         } catch (IOException e) {
             throw new TransportException(e);
         }

--- a/src/main/java/org/jscep/transport/UrlConnectionPostTransport.java
+++ b/src/main/java/org/jscep/transport/UrlConnectionPostTransport.java
@@ -68,6 +68,7 @@ final class UrlConnectionPostTransport extends AbstractTransport {
         }
 
         URL url = getUrl(msg.getOperation());
+        String userInfo = getUserInfo();
         HttpURLConnection conn;
         try {
             conn = (HttpURLConnection) url.openConnection();
@@ -75,6 +76,10 @@ final class UrlConnectionPostTransport extends AbstractTransport {
             conn.setRequestProperty("Content-Type", "application/octet-stream");
             if(conn instanceof HttpsURLConnection && sslSocketFactory != null){
                 ((HttpsURLConnection) conn).setSSLSocketFactory(sslSocketFactory);
+            }
+            if (userInfo != null && !userInfo.isEmpty()) {
+              String encoded = new String(Base64.encode(userInfo.getBytes(Charsets.US_ASCII.name())), Charsets.US_ASCII.name());
+              conn.setRequestProperty("Authorization", "Basic " + encoded);
             }
         } catch (IOException e) {
             throw new TransportException(e);


### PR DESCRIPTION
This enables BasicAuth against a SCEP-Server if user & password are in the SCEP-Server URL. Issues a warning on stderr if BasicAuth is used w/o SSL/TLS transport layer security.