### PR TITLE
Fix generation of signed data for CRL

### DIFF
--- a/src/main/java/org/jscep/server/ScepServlet.java
+++ b/src/main/java/org/jscep/server/ScepServlet.java
@@ -370,7 +370,7 @@ public abstract class ScepServlet extends HttpServlet {
         } else {
             store = new JcaCRLStore(Collections.singleton(crl));
         }
-        generator.addCertificates(store);
+        generator.addCRLs(store);
         return generator.generate(new CMSAbsentContent());
     }
 


### PR DESCRIPTION
The code for generating the CMS signed data with a CRL was wrong. Code includes fix and simple test case.