### PR TITLE
Change usages from commons-lang  to commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,9 +306,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.12.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/src/main/java/org/jscep/client/verification/MessageDigestCertificateVerifier.java
+++ b/src/main/java/org/jscep/client/verification/MessageDigestCertificateVerifier.java
@@ -5,7 +5,7 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/jscep/message/PkiMessage.java
+++ b/src/main/java/org/jscep/message/PkiMessage.java
@@ -21,9 +21,9 @@
  */
 package org.jscep.message;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.jscep.transaction.MessageType;
 import org.jscep.transaction.Nonce;
 import org.jscep.transaction.TransactionId;

--- a/src/main/java/org/jscep/message/PkiRequest.java
+++ b/src/main/java/org/jscep/message/PkiRequest.java
@@ -21,7 +21,7 @@
  */
 package org.jscep.message;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.jscep.transaction.MessageType;
 import org.jscep.transaction.Nonce;
 import org.jscep.transaction.TransactionId;

--- a/src/main/java/org/jscep/transaction/Nonce.java
+++ b/src/main/java/org/jscep/transaction/Nonce.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.Random;
 
 import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * This class represents the <code>senderNonce</code> and

--- a/src/main/java/org/jscep/transaction/TransactionId.java
+++ b/src/main/java/org/jscep/transaction/TransactionId.java
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.Charsets;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * This class represents a SCEP <code>transactionID</code> attribute.


### PR DESCRIPTION
Does this pull request add a feature or solve a bug?
As commons-lang jar is outdated and not supported anymore by Apache, switching to commons-lang3.
[#149](https://github.com/jscep/jscep/issues/149)