### PR TITLE
Add RenewalReq request

### DIFF
--- a/src/main/java/org/jscep/message/PkiMessageDecoder.java
+++ b/src/main/java/org/jscep/message/PkiMessageDecoder.java
@@ -218,8 +218,13 @@ public final class PkiMessageDecoder {
                 } catch (IOException e) {
                     throw new MessageDecodingException(e);
                 }
+
                 LOGGER.debug("Finished decoding pkiMessage");
-                return new PkcsReq(transId, senderNonce, messageData);
+                if (messageType == MessageType.PKCS_REQ) {
+                    return new PkcsReq(transId, senderNonce, messageData);
+                }
+
+                return new RenewalReq(transId, senderNonce, messageData);
             }
         }
     }

--- a/src/main/java/org/jscep/message/RenewalReq.java
+++ b/src/main/java/org/jscep/message/RenewalReq.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2010 ThruPoint Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jscep.message;
+
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.jscep.transaction.MessageType;
+import org.jscep.transaction.Nonce;
+import org.jscep.transaction.TransactionId;
+
+/**
+ * This class represents {@code PKCSReq} {@code pkiMessage}, which wraps a
+ * PKCS #10 {@code CertificationRequest} object.
+ */
+public class RenewalReq extends PkiRequest<PKCS10CertificationRequest> {
+    /**
+     * Creates a new {@code RenewalReq} instance.
+     *
+     * @param transId
+     *            the transaction ID for this request.
+     * @param senderNonce
+     *            the nonce for this request.
+     * @param messageData
+     *            the {@code CertificationRequest} to use in enrollment.
+     */
+    public RenewalReq(final TransactionId transId, final Nonce senderNonce,
+            final PKCS10CertificationRequest messageData) {
+        super(transId, MessageType.RENEWAL_REQ, senderNonce, messageData);
+    }
+}

--- a/src/main/java/org/jscep/server/ScepServlet.java
+++ b/src/main/java/org/jscep/server/ScepServlet.java
@@ -286,12 +286,15 @@ public abstract class ScepServlet extends HttpServlet {
                     LOGGER.error("Error executing GetCRL request", e);
                     throw new ServletException(e);
                 }
-            } else if (msgType == MessageType.PKCS_REQ) {
+            } else if (msgType == MessageType.PKCS_REQ || msgType == MessageType.RENEWAL_REQ) {
                 final PKCS10CertificationRequest certReq = (PKCS10CertificationRequest) msgData;
 
                 try {
                     LOGGER.debug("Invoking doEnrol");
-                    List<X509Certificate> issued = doEnrol(certReq, reqCert, transId);
+
+                    List<X509Certificate> issued =
+                        msgType == MessageType.PKCS_REQ ? doEnrol(certReq, reqCert, transId) :
+                            doRenew(certReq, reqCert, transId);
 
                     if (issued.isEmpty()) {
                         certRep = new CertRep(transId, senderNonce,
@@ -570,6 +573,33 @@ public abstract class ScepServlet extends HttpServlet {
             final PKCS10CertificationRequest certificationRequest,
             final X509Certificate sender,
             final TransactionId transId) throws Exception;
+
+    /**
+     * Renews a certificate into the PKI represented by this SCEP interface. If
+     * the request can be completed immediately, this method returns an
+     * appropriate certificate chain. If the request is pending, this method
+     * should return null or any empty list.
+     *
+     * @param certificationRequest
+     *            the PKCS #10 CertificationRequest
+     * @param transId
+     *            the transaction ID
+     * @param sender
+     *            the sender of the certificate
+     * @return the certificate chain, if any
+     * @throws OperationFailureException
+     *             if the operation cannot be completed
+     * @throws Exception
+     *             if any problem occurs
+     */
+    protected List<X509Certificate> doRenew(
+            final PKCS10CertificationRequest certificationRequest,
+            final X509Certificate sender,
+            final TransactionId transId) throws Exception {
+
+        throw new UnsupportedOperationException("Override this function to support renewals." +
+                "This method will become abstract in the next major version update.");
+    }
 
     /**
      * Returns the private key of the recipient entity represented by this SCEP

--- a/src/main/java/org/jscep/transaction/MessageType.java
+++ b/src/main/java/org/jscep/transaction/MessageType.java
@@ -9,6 +9,10 @@ public enum MessageType {
      */
     CERT_REP(3),
     /**
+     * PKCS #10 certificate request for renewal.
+     */
+    RENEWAL_REQ(17),
+    /**
      * PKCS #10 certificate request.
      */
     PKCS_REQ(19),


### PR DESCRIPTION
- It looks like Jscep currently supports passwordless renewal through PKCSReq. This PR adds support for RenewalReq explicitly (listed in RFC 8894)

- I marked the new method doRenew as concrete for now so that this PR doesn't break everyone who is using it today.

Does this pull request add a feature or solve a bug? Adds a feature
