### PR TITLE
Make message decoding more interoperable for signature verification

### DIFF
--- a/src/main/java/org/jscep/message/PkiMessageDecoder.java
+++ b/src/main/java/org/jscep/message/PkiMessageDecoder.java
@@ -131,6 +131,8 @@ public final class PkiMessageDecoder {
                             .getCertificate( cert );
                     verifier = new JcaSimpleSignerInfoVerifierBuilder().build(javaCert.getPublicKey());
                 }
+                // ensure that the encoding used of the signed attributes are the one specified in the original message
+                signerInfo = new SCEPSignerInformation(signerInfo);
                 if (signerInfo.verify(verifier) == false) {
                     final String msg = "pkiMessage verification failed.";
                     LOGGER.warn(msg);
@@ -285,5 +287,17 @@ public final class PkiMessageDecoder {
                 .getAttrValues().getObjectAt(0);
 
         return FailInfo.valueOf(Integer.valueOf(string.getString()));
+    }
+
+    private static class SCEPSignerInformation extends SignerInformation {
+
+        protected SCEPSignerInformation(SignerInformation baseInfo) {
+            super(baseInfo);
+        }
+
+        public byte[] getEncodedSignedAttributes()
+                throws IOException {
+            return signedAttributeSet.getEncoded();
+        }
     }
 }


### PR DESCRIPTION
Ensure that the encoding used for the signed attributes is the one specified in the original message

Reason behind that:
- some SCEP clients do not fully comply with RFC 5652, and e.g. encode the signed attributes in BER or other attributes ordering issues
- BC by defaults rebuilds the signed attributes before verification using ASN1Encoding.DER
As a result, verification fails because the hash of the signed attributes does not match the signature, since the signed attributes have been rebuilt.
More information there: https://github.com/bcgit/bc-java/issues/1365

The current PR allows to retrieve the "raw" signed attributes, coming from the request, instead of rebuilding them for signature verification.
