### PR TITLE
Add challengePassword encryption/decryption for non RSA recipients.

### DIFF
--- a/src/main/java/org/jscep/client/Client.java
+++ b/src/main/java/org/jscep/client/Client.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.x500.X500Principal;
 
@@ -703,10 +704,11 @@ public final class Client {
         Capabilities caps = getCaCapabilities(profile);
         CertStoreInspector certs = inspectorFactory.getInstance(store);
         X509Certificate recipientCertificate = certs.getRecipient();
+        String challengePassword = getChallengePassword(profile);
         PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(
-                recipientCertificate, caps.getStrongestCipher());
+                recipientCertificate, challengePassword, caps.getStrongestCipher());
 
-        String sigAlg = caps.getStrongestSignatureAlgorithm();
+        String sigAlg = caps.getStrongestSignatureAlgorithm(priKey.getAlgorithm());
         return new PkiMessageEncoder(priKey, identity, envEncoder, sigAlg);
     }
 
@@ -715,8 +717,9 @@ public final class Client {
         final CertStore store = getCaCertificate(profile);
         CertStoreInspector certs = inspectorFactory.getInstance(store);
         X509Certificate signer = certs.getSigner();
+        String challengePassword = getChallengePassword(profile);
         PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(
-                identity, key);
+                identity, key, challengePassword);
 
         return new PkiMessageDecoder(signer, envDecoder);
     }
@@ -733,6 +736,26 @@ public final class Client {
             return transportFactory.forMethod(Method.POST, url);
         } else {
             return transportFactory.forMethod(Method.GET, url);
+        }
+    }
+
+    /**
+     * Get challenge password using CallbackHandler and PasswordCallback
+     * @param profile the SCEP server profile
+     * @return challenge password or null
+     */
+    private String getChallengePassword(String profile) throws ClientException {
+        try {
+            LOGGER.debug("Requesting challenge password.");
+            PasswordCallback callback = new PasswordCallback("Enter challenge password for " + profile, false);
+            Callback[] callbacks = new Callback[1];
+            callbacks[0] = callback;
+            handler.handle(callbacks);
+            char[] password = callback.getPassword();
+            return password != null ? new String(password) : null;
+        } catch (Exception e) {
+            LOGGER.debug("Requesting challenge password failed.");
+            throw new ClientException(e);
         }
     }
 

--- a/src/main/java/org/jscep/client/Client.java
+++ b/src/main/java/org/jscep/client/Client.java
@@ -747,7 +747,8 @@ public final class Client {
     private String getChallengePassword(String profile) throws ClientException {
         try {
             LOGGER.debug("Requesting challenge password.");
-            PasswordCallback callback = new PasswordCallback("Enter challenge password for " + profile, false);
+            PasswordCallback callback = new PasswordCallback("Enter challenge password"
+                + (profile != null ? " for " + profile : ""), false);
             Callback[] callbacks = new Callback[1];
             callbacks[0] = callback;
             handler.handle(callbacks);

--- a/src/main/java/org/jscep/client/DefaultCallbackHandler.java
+++ b/src/main/java/org/jscep/client/DefaultCallbackHandler.java
@@ -1,9 +1,12 @@
 package org.jscep.client;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 
 import org.jscep.client.verification.CertificateVerifier;
@@ -16,6 +19,7 @@ public final class DefaultCallbackHandler implements CallbackHandler {
      * The verifier.
      */
     private final CertificateVerifier verifier;
+    private final Map<String, String> passwords;
 
     /**
      * Default callback handler that delegates verification to a verifier.
@@ -23,8 +27,19 @@ public final class DefaultCallbackHandler implements CallbackHandler {
      * @param verifier
      *            the verifier to use.
      */
-    public DefaultCallbackHandler(final CertificateVerifier verifier) {
+    public DefaultCallbackHandler(final CertificateVerifier verifier, final Map<String, String> passwords) {
         this.verifier = verifier;
+        this.passwords = passwords;
+    }
+
+    /**
+     * Default callback handler that delegates verification to a verifier.
+     *
+     * @param verifier
+     *            the verifier to use.
+     */
+    public DefaultCallbackHandler(final CertificateVerifier verifier) {
+        this(verifier, new HashMap<>());
     }
 
     /**
@@ -36,6 +51,8 @@ public final class DefaultCallbackHandler implements CallbackHandler {
         for (Callback callback : callbacks) {
             if (callback instanceof CertificateVerificationCallback) {
                 verify(CertificateVerificationCallback.class.cast(callback));
+            } else if (callback instanceof PasswordCallback) {
+                handle(PasswordCallback.class.cast(callback));
             } else {
                 throw new UnsupportedCallbackException(callback);
             }
@@ -52,4 +69,25 @@ public final class DefaultCallbackHandler implements CallbackHandler {
         callback.setVerified(verifier.verify(callback.getCertificate()));
     }
 
+    /**
+     * Provide specific password based on profile name in callback's prompt.
+     *
+     * @param callback the callback to handle
+     */
+    private void handle(final PasswordCallback callback) {
+        if (passwords == null) {
+            return;
+        }
+        if (passwords.size() == 1) {
+            // we have only one password, just return it
+            callback.setPassword(passwords.get(passwords.keySet().iterator().next()).toCharArray());
+        } else {
+            // if we have many passwords, return one selected by profile name included in prompt
+            for (String key : passwords.keySet()) {
+                if (callback.getPrompt().contains(key)) {
+                    callback.setPassword(passwords.get(key).toCharArray());
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/org/jscep/client/DefaultCallbackHandler.java
+++ b/src/main/java/org/jscep/client/DefaultCallbackHandler.java
@@ -80,7 +80,10 @@ public final class DefaultCallbackHandler implements CallbackHandler {
         }
         if (passwords.size() == 1) {
             // we have only one password, just return it
-            callback.setPassword(passwords.get(passwords.keySet().iterator().next()).toCharArray());
+            String password = passwords.get(passwords.keySet().iterator().next());
+            if (password != null) {
+                callback.setPassword(password.toCharArray());
+            }
         } else {
             // if we have many passwords, return one selected by profile name included in prompt
             for (String key : passwords.keySet()) {

--- a/src/main/java/org/jscep/server/ScepServlet.java
+++ b/src/main/java/org/jscep/server/ScepServlet.java
@@ -200,7 +200,7 @@ public abstract class ScepServlet extends HttpServlet {
             PkiMessage<?> msg;
             try {
                 PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(
-                        getRecipient(), getRecipientKey());
+                        getRecipient(), getRecipientKey(), getChallengePassword());
                 PkiMessageDecoder decoder = new PkiMessageDecoder(reqCert,
                         envDecoder);
                 msg = decoder.decode(sd);
@@ -313,7 +313,7 @@ public abstract class ScepServlet extends HttpServlet {
             }
 
             PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(
-                    reqCert, "DESede");
+                    reqCert, getChallengePassword(), "DESede");
             PkiMessageEncoder encoder = new PkiMessageEncoder(getSignerKey(),
                     getSigner(), getSignerCertificateChain(), envEncoder);
             CMSSignedData signedData;
@@ -570,6 +570,13 @@ public abstract class ScepServlet extends HttpServlet {
             final PKCS10CertificationRequest certificationRequest,
             final X509Certificate sender,
             final TransactionId transId) throws Exception;
+
+    /**
+     * Returns challenge password.
+     *
+     * @return challenge password
+     */
+    protected abstract String getChallengePassword();
 
     /**
      * Returns the private key of the recipient entity represented by this SCEP

--- a/src/main/java/org/jscep/transport/response/Capabilities.java
+++ b/src/main/java/org/jscep/transport/response/Capabilities.java
@@ -174,13 +174,13 @@ public final class Capabilities {
         if (keyAlgorithm.equals("EC")) {
             keyAlgorithm = "ECDSA";
         }
-        if (sigExists("SHA512") && caps.contains(Capability.SHA_512)) {
+        if (sigExists("SHA512", keyAlgorithm) && caps.contains(Capability.SHA_512)) {
             return "SHA512with" + keyAlgorithm;
-        } else if (sigExists("SHA256") && caps.contains(Capability.SHA_256)) {
+        } else if (sigExists("SHA256", keyAlgorithm) && caps.contains(Capability.SHA_256)) {
             return "SHA256with" + keyAlgorithm;
-        } else if (sigExists("SHA1") && caps.contains(Capability.SHA_1)) {
+        } else if (sigExists("SHA1", keyAlgorithm) && caps.contains(Capability.SHA_1)) {
             return "SHA1with" + keyAlgorithm;
-        } else if (sigExists("MD5")) {
+        } else if (sigExists("MD5", keyAlgorithm)) {
             return "MD5with" + keyAlgorithm;
         }
         return null;
@@ -194,10 +194,10 @@ public final class Capabilities {
         return getStrongestSignatureAlgorithm("RSA");
     }
 
-    private boolean sigExists(final String sig) {
-        return (algorithmExists("Signature", sig + "withRSA")
-                || algorithmExists("Signature", sig + "WithRSAEncryption"))
-                && digestExists(sig);
+    private boolean sigExists(final String dig, final String sig) {
+        return (algorithmExists("Signature", dig + "with" + sig)
+                || algorithmExists("Signature", dig + "With" + sig + "Encryption"))
+                && digestExists(dig);
     }
 
     private boolean digestExists(final String digest) {

--- a/src/main/java/org/jscep/transport/response/Capabilities.java
+++ b/src/main/java/org/jscep/transport/response/Capabilities.java
@@ -165,17 +165,33 @@ public final class Capabilities {
         return null;
     }
 
-    public String getStrongestSignatureAlgorithm() {
+    /**
+     * Return the strongest signature algorithm supported by the server for the specified key algorithm
+     * @param keyAlgorithm signing key algorithm name (as returned from PrivateKey.getAlgorithm() function)
+     * @return signature algorithm name
+     */
+    public String getStrongestSignatureAlgorithm(String keyAlgorithm) {
+        if (keyAlgorithm.equals("EC")) {
+            keyAlgorithm = "ECDSA";
+        }
         if (sigExists("SHA512") && caps.contains(Capability.SHA_512)) {
-            return "SHA512withRSA";
+            return "SHA512with" + keyAlgorithm;
         } else if (sigExists("SHA256") && caps.contains(Capability.SHA_256)) {
-            return "SHA256withRSA";
+            return "SHA256with" + keyAlgorithm;
         } else if (sigExists("SHA1") && caps.contains(Capability.SHA_1)) {
-            return "SHA1withRSA";
+            return "SHA1with" + keyAlgorithm;
         } else if (sigExists("MD5")) {
-            return "MD5withRSA";
+            return "MD5with" + keyAlgorithm;
         }
         return null;
+    }
+
+    /**
+     * Return the strongest signature algorithm supported by the server for the RSA key
+     * @return signature algorithm name
+     */
+    public String getStrongestSignatureAlgorithm() {
+        return getStrongestSignatureAlgorithm("RSA");
     }
 
     private boolean sigExists(final String sig) {

--- a/src/test/java/org/jscep/message/PkiMessageEncoderTest.java
+++ b/src/test/java/org/jscep/message/PkiMessageEncoderTest.java
@@ -145,6 +145,7 @@ public class PkiMessageEncoderTest {
         KeyPair caPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
         X509Certificate ca = X509Certificates.createEphemeral(
                 new X500Principal("CN=CA"), caPair);
+        String challengePassword = "secret";
 
         KeyPair clientPair = KeyPairGenerator.getInstance("RSA")
                 .generateKeyPair();
@@ -153,12 +154,12 @@ public class PkiMessageEncoderTest {
 
         // Everything below this line only available to client
         PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(ca,
-                "DES");
+            challengePassword, "DES");
         PkiMessageEncoder encoder = new PkiMessageEncoder(
                 clientPair.getPrivate(), client, envEncoder);
 
         PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(ca,
-                caPair.getPrivate());
+                caPair.getPrivate(), challengePassword);
 
         PkiMessageDecoder decoder = new PkiMessageDecoder(client, envDecoder);
 
@@ -238,6 +239,7 @@ public class PkiMessageEncoderTest {
     	KeyPair caPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
         X509Certificate ca = X509Certificates.createEphemeral(
                 new X500Principal("CN=CA"), caPair);
+        String challengePassword = "secret";
 
         KeyPair clientPair = KeyPairGenerator.getInstance("RSA")
                 .generateKeyPair();
@@ -246,12 +248,12 @@ public class PkiMessageEncoderTest {
 
         // Everything below this line only available to client
         PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(ca,
-                cipherAlgorithm);
+            challengePassword, cipherAlgorithm);
         PkiMessageEncoder encoder = new PkiMessageEncoder(
                 clientPair.getPrivate(), client, envEncoder);
 
         PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(ca,
-                caPair.getPrivate());
+                caPair.getPrivate(), challengePassword);
         PkiMessageDecoder decoder = new PkiMessageDecoder(client, envDecoder);
 
         PkiMessage<?> actual = decoder.decode(encoder.encode(message));

--- a/src/test/java/org/jscep/server/ScepServletImpl.java
+++ b/src/test/java/org/jscep/server/ScepServletImpl.java
@@ -60,6 +60,7 @@ public class ScepServletImpl extends ScepServlet {
     private X500Name name;
     private X500Name pollName;
     private BigInteger caSerial;
+    private String challengePassword;
 
     public void init(ServletContext context) {
         LOGGER.debug("INIT");
@@ -70,6 +71,7 @@ public class ScepServletImpl extends ScepServlet {
         name = new X500Name("CN=Certification Authority");
         pollName = new X500Name("CN=Poll");
         caSerial = BigInteger.TEN;
+        challengePassword = "password";
         try {
 
             KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
@@ -130,7 +132,7 @@ public class ScepServletImpl extends ScepServlet {
             String password = CertificationRequestUtils.getChallengePassword(csr);
             if (password == null) {
                 authorizeRenewal(sender);
-            } else if (!password.equals("password")) {
+            } else if (!password.equals(challengePassword)) {
                 LOGGER.debug("Invalid password");
                 throw new OperationFailureException(FailInfo.badRequest);
             }
@@ -225,6 +227,11 @@ public class ScepServletImpl extends ScepServlet {
             return Collections.singletonList(ca);
         }
         return Collections.emptyList();
+    }
+
+    @Override
+    protected String getChallengePassword() {
+        return challengePassword;
     }
 
     @Override

--- a/src/test/java/org/jscep/server/ScepServletTest.java
+++ b/src/test/java/org/jscep/server/ScepServletTest.java
@@ -89,6 +89,7 @@ public class ScepServletTest {
     private String goodIdentifier;
     private String badIdentifier;
     private TransportFactory transportFactory;
+    private String challengePassword;
 
     @Before
     public void configureFixtures() throws Exception {
@@ -103,6 +104,7 @@ public class ScepServletTest {
         pubKey = keyPair.getPublic();
         sender = generateCertificate();
         transportFactory = new UrlConnectionTransportFactory();
+        challengePassword = "secret";
 
     }
 
@@ -194,12 +196,12 @@ public class ScepServletTest {
     public void testGetCRL() throws Exception {
         IssuerAndSerialNumber iasn = new IssuerAndSerialNumber(name, goodSerial);
         PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(
-                getRecipient(), "DESede");
+                getRecipient(), challengePassword, "DESede");
         PkiMessageEncoder encoder = new PkiMessageEncoder(priKey, sender,
                 envEncoder);
 
         PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(sender,
-                priKey);
+                priKey, challengePassword);
         PkiMessageDecoder decoder = new PkiMessageDecoder(getRecipient(),
                 envDecoder);
 
@@ -215,12 +217,12 @@ public class ScepServletTest {
     public void testGetCertBad() throws Exception {
         IssuerAndSerialNumber iasn = new IssuerAndSerialNumber(name, badSerial);
         PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(
-                getRecipient(), "DES");
+                getRecipient(), challengePassword, "DES");
         PkiMessageEncoder encoder = new PkiMessageEncoder(priKey, sender,
                 envEncoder);
 
         PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(sender,
-                priKey);
+                priKey, challengePassword);
         PkiMessageDecoder decoder = new PkiMessageDecoder(getRecipient(),
                 envDecoder);
 
@@ -238,12 +240,12 @@ public class ScepServletTest {
                 "password".toCharArray());
 
         PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(
-                getRecipient(), "DESede");
+                getRecipient(), challengePassword, "DESede");
         PkiMessageEncoder encoder = new PkiMessageEncoder(priKey, sender,
                 envEncoder);
 
         PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(sender,
-                priKey);
+                priKey, challengePassword);
         PkiMessageDecoder decoder = new PkiMessageDecoder(getRecipient(),
                 envDecoder);
 
@@ -261,12 +263,12 @@ public class ScepServletTest {
                 "password".toCharArray());
 
         PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(
-                getRecipient(), "DES");
+                getRecipient(), challengePassword, "DES");
         PkiMessageEncoder encoder = new PkiMessageEncoder(priKey, sender,
                 envEncoder);
 
         PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(sender,
-                priKey);
+                priKey, challengePassword);
         PkiMessageDecoder decoder = new PkiMessageDecoder(getRecipient(),
                 envDecoder);
 
@@ -284,12 +286,12 @@ public class ScepServletTest {
                 "password".toCharArray());
 
         PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(
-                getRecipient(), "DES");
+                getRecipient(), challengePassword, "DES");
         PkiMessageEncoder encoder = new PkiMessageEncoder(priKey, sender,
                 envEncoder);
 
         PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(sender,
-                priKey);
+                priKey, challengePassword);
         PkiMessageDecoder decoder = new PkiMessageDecoder(getRecipient(),
                 envDecoder);
 
@@ -312,12 +314,12 @@ public class ScepServletTest {
         PKCS10CertificationRequest csr = getCsr(name, pubKey, priKey);
 
         PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(
-                getRecipient(), "DES");
+                getRecipient(), challengePassword, "DES");
         PkiMessageEncoder encoder = new PkiMessageEncoder(priKey, sender,
                 envEncoder);
 
         PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(sender,
-                priKey);
+                priKey, challengePassword);
         PkiMessageDecoder decoder = new PkiMessageDecoder(getRecipient(),
                 envDecoder);
 
@@ -336,12 +338,12 @@ public class ScepServletTest {
                 "password".toCharArray());
 
         PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(
-                getRecipient(), "DES");
+                getRecipient(), challengePassword, "DES");
         PkiMessageEncoder encoder = new PkiMessageEncoder(priKey, sender,
                 envEncoder);
 
         PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(sender,
-                priKey);
+                priKey, challengePassword);
         PkiMessageDecoder decoder = new PkiMessageDecoder(getRecipient(),
                 envDecoder);
 
@@ -362,7 +364,7 @@ public class ScepServletTest {
         PublicKey newPubKey = keyPair.getPublic();
         csr = getCsr(name, newPubKey, newPriKey);
         encoder = new PkiMessageEncoder(priKey, prevCertificate, envEncoder);
-        envDecoder = new PkcsPkiEnvelopeDecoder(prevCertificate, priKey);
+        envDecoder = new PkcsPkiEnvelopeDecoder(prevCertificate, priKey, challengePassword);
         decoder = new PkiMessageDecoder(getRecipient(), envDecoder);
         t = new EnrollmentTransaction(transport, encoder, decoder, csr);
         State renewalSate = t.send();

--- a/src/test/java/org/jscep/transport/AbstractTransportTest.java
+++ b/src/test/java/org/jscep/transport/AbstractTransportTest.java
@@ -32,6 +32,7 @@ abstract public class AbstractTransportTest {
     protected Proxy proxy;
     protected Transport transport;
     private Server server;
+    private String challengePassword;
 
     @Before
     public void setUp() throws Exception {
@@ -41,6 +42,7 @@ abstract public class AbstractTransportTest {
                 + server.getConnectors()[0].getLocalPort() + "/");
         proxy = Proxy.NO_PROXY;
         transport = getTransport(url);
+        challengePassword = "secret";
     }
 
     abstract protected Transport getTransport(URL url);
@@ -55,7 +57,7 @@ abstract public class AbstractTransportTest {
         KeyPair keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
 
         PkcsPkiEnvelopeEncoder envEnc = new PkcsPkiEnvelopeEncoder(
-                getCertificate(keyPair), "DES");
+                getCertificate(keyPair), challengePassword, "DES");
         PkiMessageEncoder enc = new PkiMessageEncoder(keyPair.getPrivate(),
                 getCertificate(keyPair), envEnc);
 


### PR DESCRIPTION
Adds challengePassword encryption/decryption for non RSA recipients. This solves issue https://github.com/jscep/jscep/issues/300.

The goal was to minimally modify the existing interface, so all public API prototypes were retained. Only the DefaultCallbackHandler class has been extended to allow for providing the required challenge password values. Here is an example:
```
CertificateVerifier verifier = new ConsoleCertificateVerifier();
Map<String, String> passwords = new HashMap<>();
passwords.put("CA1", "secret1");
passwords.put("CA2", "secret2");
CallbackHandler handler = new DefaultCallbackHandler(verifier, passwords);
```
More details [here](https://github.com/netcat-pl/jscep/tree/feature/recipient_info_pwri#default-callback-mechanism).

Does this pull request add a feature or solve a bug? Yes, it does. It's a new feature PR.