### PR TITLE
feature: add option for definite-length BER encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ client.setTransportFactory(new UrlConnectionTransportFactory(factory));
 
 Ernst-Georg Schmid has created a transport which uses HTTP Basic authentication.  You can find his repo at [ergo70/jscep-basic-auth](https://github.com/ergo70/jscep-basic-auth).
 
+### ASN.1 encoding
+
+Some SCEP servers require definite-length BER encoding and reject messages with indefinite-length encoding. By default, jscep uses indefinite-length encoding. To use definite-length encoding, set the `AsnEncoding` option on the client:
+
+```java
+Client client = new Client(url, handler);
+client.setAsnEncoding(AsnEncoding.DL);
+```
+
+This encoding is applied to both the inner `CMSEnvelopedData` and the outer `CMSSignedData` structures.
+
 ## Creating a Callback Handler
 
 The callback handler is used to verify the CA certificate being sent by the SCEP server is the certificate you expect.  With jscep, you can choose to use either the default callback mechanism with a choice of certificate verifiers, or to provide your own callback handler.

--- a/src/main/java/org/jscep/client/Client.java
+++ b/src/main/java/org/jscep/client/Client.java
@@ -56,6 +56,7 @@ import org.jscep.client.inspect.CertStoreInspector;
 import org.jscep.client.inspect.CertStoreInspectorFactory;
 import org.jscep.client.inspect.DefaultCertStoreInspectorFactory;
 import org.jscep.client.verification.CertificateVerifier;
+import org.jscep.message.AsnEncoding;
 import org.jscep.message.PkcsPkiEnvelopeDecoder;
 import org.jscep.message.PkcsPkiEnvelopeEncoder;
 import org.jscep.message.PkiMessageDecoder;
@@ -127,6 +128,7 @@ public final class Client {
     private final CallbackHandler handler;
     private CertStoreInspectorFactory inspectorFactory = new DefaultCertStoreInspectorFactory();
     private TransportFactory transportFactory = new UrlConnectionTransportFactory();
+    private AsnEncoding asnEncoding = AsnEncoding.BER;
 
 	/**
      * Constructs a new {@code Client} instance using the provided
@@ -707,7 +709,8 @@ public final class Client {
                 recipientCertificate, caps.getStrongestCipher());
 
         String sigAlg = caps.getStrongestSignatureAlgorithm();
-        return new PkiMessageEncoder(priKey, identity, envEncoder, sigAlg);
+        return new PkiMessageEncoder(priKey, identity, envEncoder, sigAlg,
+                asnEncoding);
     }
 
     private PkiMessageDecoder getDecoder(final X509Certificate identity,
@@ -767,5 +770,15 @@ public final class Client {
     public synchronized void setTransportFactory(
     		final TransportFactory transportFactory) {
     	this.transportFactory = transportFactory;
+    }
+
+    /**
+     * Sets the ASN.1 encoding type for SCEP messages.
+     *
+     * @param asnEncoding
+     *            the encoding type to use
+     */
+    public synchronized void setAsnEncoding(final AsnEncoding asnEncoding) {
+        this.asnEncoding = asnEncoding;
     }
 }

--- a/src/main/java/org/jscep/message/AsnEncoding.java
+++ b/src/main/java/org/jscep/message/AsnEncoding.java
@@ -1,0 +1,42 @@
+package org.jscep.message;
+
+/**
+ * ASN.1 encoding types for CMS structures.
+ * <p>
+ * Some SCEP servers require definite-length encoding for compatibility.
+ * The default behavior uses indefinite-length BER encoding.
+ */
+public enum AsnEncoding {
+    /**
+     * Basic Encoding Rules with indefinite-length encoding.
+     * This is the default and most flexible encoding.
+     */
+    BER("BER"),
+
+    /**
+     * Definite-length BER encoding.
+     * Use this when the recipient requires fixed-length encoding.
+     */
+    DL("DL"),
+
+    /**
+     * Distinguished Encoding Rules.
+     * The strictest encoding, always uses definite-length.
+     */
+    DER("DER");
+
+    private final String encoding;
+
+    AsnEncoding(final String encoding) {
+        this.encoding = encoding;
+    }
+
+    /**
+     * Returns the encoding identifier string.
+     *
+     * @return the encoding identifier
+     */
+    public String getEncoding() {
+        return encoding;
+    }
+}

--- a/src/main/java/org/jscep/message/PkiMessageEncoder.java
+++ b/src/main/java/org/jscep/message/PkiMessageEncoder.java
@@ -66,6 +66,7 @@ public final class PkiMessageEncoder {
     private X509Certificate[] chain = null;
     private final PkcsPkiEnvelopeEncoder enveloper;
     private final String signatureAlgorithm;
+    private AsnEncoding asnEncoding = AsnEncoding.BER;
 
     /**
      * Creates a new {@code PkiMessageEncoder} instance.
@@ -155,6 +156,29 @@ public final class PkiMessageEncoder {
     }
 
     /**
+     * Creates a new {@code PkiMessageEncoder} instance with specified ASN.1 encoding.
+     *
+     * @param signerKey
+     *            the key to use to sign the {@code signedData}.
+     * @param signerId
+     *            the certificate to use to identify the signer.
+     * @param enveloper
+     *            the enveloper used for encoding the {@code messageData}
+     * @param signatureAlgorithm
+     *            the algorithm used for signing the {@code messageData}
+     * @param asnEncoding
+     *            the ASN.1 encoding type to use
+     */
+    public PkiMessageEncoder(final PrivateKey signerKey,
+                             final X509Certificate signerId,
+                             final PkcsPkiEnvelopeEncoder enveloper,
+                             final String signatureAlgorithm,
+                             final AsnEncoding asnEncoding) {
+        this(signerKey, signerId, enveloper, signatureAlgorithm);
+        this.asnEncoding = asnEncoding;
+    }
+
+    /**
      * Encodes the provided {@code PkiMessage} into a PKCS #7
      * {@code signedData}.
      *
@@ -203,7 +227,8 @@ public final class PkiMessageEncoder {
         if (hasMessageData) {
             try {
                 CMSEnvelopedData ed = encodeMessage(message);
-                signable = new CMSProcessableByteArray(ed.getEncoded());
+                signable = new CMSProcessableByteArray(
+                        ed.getEncoded(asnEncoding.getEncoding()));
             } catch (IOException e) {
                 throw new MessageEncodingException(e);
             }
@@ -294,5 +319,14 @@ public final class PkiMessageEncoder {
 
     private ContentSigner getContentSigner() throws OperatorCreationException {
         return new JcaContentSignerBuilder(signatureAlgorithm).build(signerKey);
+    }
+
+    /**
+     * Returns the ASN.1 encoding type used by this encoder.
+     *
+     * @return the encoding type
+     */
+    public AsnEncoding getAsnEncoding() {
+        return asnEncoding;
     }
 }

--- a/src/main/java/org/jscep/transaction/EnrollmentTransaction.java
+++ b/src/main/java/org/jscep/transaction/EnrollmentTransaction.java
@@ -109,7 +109,8 @@ public final class EnrollmentTransaction extends Transaction {
         }
         LOGGER.debug("Sending {}", signedData);
         PkiOperationResponseHandler handler = new PkiOperationResponseHandler();
-        CMSSignedData res = send(handler, new PkiOperationRequest(signedData));
+        CMSSignedData res = send(handler,
+                new PkiOperationRequest(signedData, getAsnEncoding()));
         LOGGER.debug("Received response {}", res);
 
         CertRep response;

--- a/src/main/java/org/jscep/transaction/NonEnrollmentTransaction.java
+++ b/src/main/java/org/jscep/transaction/NonEnrollmentTransaction.java
@@ -85,7 +85,8 @@ public final class NonEnrollmentTransaction extends Transaction {
             throw new TransactionException(e);
         }
 
-        CMSSignedData res = send(handler, new PkiOperationRequest(signedData));
+        CMSSignedData res = send(handler,
+                new PkiOperationRequest(signedData, getAsnEncoding()));
         CertRep response;
         try {
             response = (CertRep) decode(res);

--- a/src/main/java/org/jscep/transaction/Transaction.java
+++ b/src/main/java/org/jscep/transaction/Transaction.java
@@ -3,6 +3,7 @@ package org.jscep.transaction;
 import java.security.cert.CertStore;
 
 import org.bouncycastle.cms.CMSSignedData;
+import org.jscep.message.AsnEncoding;
 import org.jscep.message.CertRep;
 import org.jscep.message.MessageDecodingException;
 import org.jscep.message.MessageEncodingException;
@@ -109,6 +110,10 @@ public abstract class Transaction {
     final CMSSignedData encode(final PkiMessage<?> message)
             throws MessageEncodingException {
         return encoder.encode(message);
+    }
+
+    final AsnEncoding getAsnEncoding() {
+        return encoder.getAsnEncoding();
     }
 
     final State pending() {

--- a/src/main/java/org/jscep/transport/request/PkiOperationRequest.java
+++ b/src/main/java/org/jscep/transport/request/PkiOperationRequest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import org.apache.commons.codec.binary.Base64;
 import org.bouncycastle.cms.CMSSignedData;
+import org.jscep.message.AsnEncoding;
 
 /**
  * The {@code PkiOperationRequest} class may represent a {@code PKCSReq},
@@ -11,18 +12,34 @@ import org.bouncycastle.cms.CMSSignedData;
  */
 public final class PkiOperationRequest extends Request {
     private final CMSSignedData msgData;
+    private final AsnEncoding asnEncoding;
 
     /**
      * Creates a new {@code PkiOperationRequest} for the given
      * {@code signedData}
-     * 
+     *
      * @param msgData
      *            the pkiMessage to use.
      */
     public PkiOperationRequest(final CMSSignedData msgData) {
+        this(msgData, AsnEncoding.BER);
+    }
+
+    /**
+     * Creates a new {@code PkiOperationRequest} for the given
+     * {@code signedData} with specified ASN.1 encoding.
+     *
+     * @param msgData
+     *            the pkiMessage to use.
+     * @param asnEncoding
+     *            the ASN.1 encoding type to use.
+     */
+    public PkiOperationRequest(final CMSSignedData msgData,
+                               final AsnEncoding asnEncoding) {
         super(Operation.PKI_OPERATION);
 
         this.msgData = msgData;
+        this.asnEncoding = asnEncoding;
     }
 
     /**
@@ -31,7 +48,8 @@ public final class PkiOperationRequest extends Request {
     @Override
     public String getMessage() {
         try {
-            return new String(Base64.encodeBase64(msgData.getEncoded(), false), "UTF-8");
+            return new String(Base64.encodeBase64(
+                    msgData.getEncoded(asnEncoding.getEncoding()), false), "UTF-8");
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/org/jscep/message/PkiMessageEncoderTest.java
+++ b/src/test/java/org/jscep/message/PkiMessageEncoderTest.java
@@ -141,6 +141,18 @@ public class PkiMessageEncoderTest {
     }
 
     @Test
+    public void simpleTestDefiniteLength() throws Exception {
+        PkiMessage<?> actual = encodeAndDecodeEnvelope("DES", AsnEncoding.DL);
+        assertEquals(message, actual);
+    }
+
+    @Test
+    public void simpleTestDER() throws Exception {
+        PkiMessage<?> actual = encodeAndDecodeEnvelope("DES", AsnEncoding.DER);
+        assertEquals(message, actual);
+    }
+
+    @Test
     public void invalidSignatureTest() throws Exception {
         KeyPair caPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
         X509Certificate ca = X509Certificates.createEphemeral(
@@ -234,8 +246,13 @@ public class PkiMessageEncoderTest {
         return new CMSSignedData(ci2);
     }
     
-    public PkiMessage<?> encodeAndDecodeEnvelope(String cipherAlgorithm) throws Exception{
-    	KeyPair caPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+    public PkiMessage<?> encodeAndDecodeEnvelope(String cipherAlgorithm) throws Exception {
+        return encodeAndDecodeEnvelope(cipherAlgorithm, AsnEncoding.BER);
+    }
+
+    public PkiMessage<?> encodeAndDecodeEnvelope(String cipherAlgorithm,
+            AsnEncoding asnEncoding) throws Exception {
+        KeyPair caPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
         X509Certificate ca = X509Certificates.createEphemeral(
                 new X500Principal("CN=CA"), caPair);
 
@@ -248,7 +265,8 @@ public class PkiMessageEncoderTest {
         PkcsPkiEnvelopeEncoder envEncoder = new PkcsPkiEnvelopeEncoder(ca,
                 cipherAlgorithm);
         PkiMessageEncoder encoder = new PkiMessageEncoder(
-                clientPair.getPrivate(), client, envEncoder);
+                clientPair.getPrivate(), client, envEncoder, "SHA1withRSA",
+                asnEncoding);
 
         PkcsPkiEnvelopeDecoder envDecoder = new PkcsPkiEnvelopeDecoder(ca,
                 caPair.getPrivate());


### PR DESCRIPTION
Some SCEP servers require definite-length encoding and reject messages
with indefinite-length BER encoding. This adds an AsnEncoding option
that can be set on the Client to control the encoding format.

Usage:
```java
    Client client = new Client(url, verifier);
    client.setAsnEncoding(AsnEncoding.DL);
```

The encoding is applied to both the inner CMSEnvelopedData and the outer CMSSignedData structures.
